### PR TITLE
Upgrade to PlayCore 1.10

### DIFF
--- a/src/StoreReview.Plugin/StoreReview.Plugin.csproj
+++ b/src/StoreReview.Plugin/StoreReview.Plugin.csproj
@@ -70,7 +70,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <Compile Include="**\*.android.cs" />
-		<PackageReference Include="PlayCore" Version="1.8.0" />
+		<PackageReference Include="PlayCore" Version="1.10.0" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #
- Fixes a minor "UI flickering in the In-App Review API" issue, the rest mostly behaves the same

Changes Proposed in this pull request:
- As you can see in the [Google Play Store release notes](https://developer.android.com/reference/com/google/android/play/core/release-notes), we are now upgrading to use the latest February version of the library
- This is [the Pull Request](https://github.com/PatGet/XamarinPlayCoreUpdater/pull/15) in the Play Core bindings library which performed the 1.10 update

**Testing**
----------
* Tested the play core package when it was published as a 1.10-rc nuget, and just like before it didn't show the In-App Review window in debug and release configurations when testing it locally
* Tested the play core package when it was publish as a 1.10-rc nuget, and just like before it showed the In-App Review window in release configurations when testing through the "Internal App Sharing" feature