### PR TITLE
Target MonoAndroid 11.0 to help Android 11 to display store review.

### DIFF
--- a/src/StoreReview.Plugin/StoreReview.Plugin.csproj
+++ b/src/StoreReview.Plugin/StoreReview.Plugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid10.0;Xamarin.Mac20;Xamarin.iOS10;uap10.0.16299;Xamarin.TVOS10;</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid11.0;Xamarin.Mac20;Xamarin.iOS10;uap10.0.16299;Xamarin.TVOS10;</TargetFrameworks>
     <AssemblyName>Plugin.StoreReview</AssemblyName>
     <RootNamespace>Plugin.StoreReview</RootNamespace>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/src/StoreReviewTest/StoreReviewTest.Android/Properties/AndroidManifest.xml
+++ b/src/StoreReviewTest/StoreReviewTest.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.storereviewtest">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
     <application android:label="StoreReviewTest.Android" android:theme="@style/MainTheme"></application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes # .
Android 11 devices  does not show up store review popup in internal channel

Changes Proposed in this pull request:
- Target MonoAndroid 11.0 to help Android 11 to display store review.
- Update Test's Manifest to target API level 30
- 
