### PR TITLE
Updated iPhone review to the newer SKStoreReviewController

### DIFF
--- a/src/StoreReview.Plugin/StoreReviewImplementation.apple.cs
+++ b/src/StoreReview.Plugin/StoreReviewImplementation.apple.cs
@@ -82,7 +82,7 @@ namespace Plugin.StoreReview
             {
 				if (IsiOS14)
 				{
-					var windowScene = UIApplication.SharedApplication.ConnectedScenes.ToArray<UIScene>()?.First(x => x.ActivationState == UISceneActivationState.ForegroundActive) as UIWindowScene;
+                	var windowScene = UIApplication.SharedApplication?.ConnectedScenes?.ToArray<UIScene>()?.FirstOrDefault(x => x.ActivationState == UISceneActivationState.ForegroundActive) as UIWindowScene;
 					if (windowScene != null)
 					{
 						SKStoreReviewController.RequestReview(windowScene);

--- a/src/StoreReview.Plugin/StoreReviewImplementation.apple.cs
+++ b/src/StoreReview.Plugin/StoreReviewImplementation.apple.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 #if !__MACOS__
 using UIKit;
+using System.Linq;
 #endif
 using StoreKit;
 
@@ -79,6 +80,15 @@ namespace Plugin.StoreReview
 #if __IOS__
             if (IsiOS103)
             {
+				if (IsiOS14)
+				{
+					var windowScene = UIApplication.SharedApplication.ConnectedScenes.ToArray<UIScene>()?.First(x => x.ActivationState == UISceneActivationState.ForegroundActive) as UIWindowScene;
+					if (windowScene != null)
+					{
+						SKStoreReviewController.RequestReview(windowScene);
+						return;
+					}
+				}
                 SKStoreReviewController.RequestReview();
             }
 #elif __MACOS__
@@ -105,6 +115,7 @@ namespace Plugin.StoreReview
 
 #if __IOS__
 		bool IsiOS103 => UIDevice.CurrentDevice.CheckSystemVersion(10, 3);
+		bool IsiOS14 => UIDevice.CurrentDevice.CheckSystemVersion(14, 0);
 #endif
 
 	}


### PR DESCRIPTION
* As mentioned in #32 , the older SKStoreReviewController.RequestReview() is deprecated and we should be using the newer one recommended by apple which takes in scenes.
* I followed the code recommended in the [Apple Forums](https://developer.apple.com/forums/thread/652157?answerId=653723022#653723022) in order to figure out the solution

**Testing**
------
* Tested in iPhone 8 Simulator running iOS 15.2
* Created a blank native app in Xamarin iOS and put in the code as you can see in the screenshots and i was able to see the review popup successfully without any exceptions

------------
Please take a moment to fill out the following:

Fixes #32

Changes Proposed in this pull request:
- Use the new SKStoreReviewController request review function

### Screenshots from testing
----------
- The code successfully calls the newer review request
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/8262287/151322978-277f90dd-0f30-4ac1-b52c-8536046282e3.png">
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/8262287/151323174-cc4eded5-3405-4f4e-b705-e5eb10ad14bb.png">

- Xamarin iOS Native Testing setup
<img width="1206" alt="Screen Shot 2022-01-27 at 3 34 31 AM" src="https://user-images.githubusercontent.com/8262287/151322849-c8dce033-0a66-4510-bc7c-353ed76b76d3.png">
